### PR TITLE
Use correct event msg params and improve log

### DIFF
--- a/dockerdiscovery.go
+++ b/dockerdiscovery.go
@@ -164,11 +164,11 @@ func (dd DockerDiscovery) getContainerAddress(container *dockerapi.Container) (n
 			continue
 		} else {
 			network, ok := container.NetworkSettings.Networks[networkMode]
-			if !ok {
+			if !ok { // sometime while "network:disconnect" event fire
 				return nil, fmt.Errorf("unable to find network settings for the network %s", networkMode)
 			}
 
-			return net.ParseIP(network.IPAddress), nil  // ParseIP return nil when IPAddress equals "" sometime while "network:disconnect" event fire
+			return net.ParseIP(network.IPAddress), nil  // ParseIP return nil when IPAddress equals ""
 		}
 	}
 }

--- a/dockerdiscovery.go
+++ b/dockerdiscovery.go
@@ -264,11 +264,11 @@ func (dd DockerDiscovery) start() error {
 
 				container, err := dd.dockerClient.InspectContainer(msg.Actor.Attributes["container"])
 				if err != nil {
-					log.Printf("[docker] Event error %s #%s: %s", event, msg.ID, err)
+					log.Printf("[docker] Event error %s #%s: %s", event, msg.Actor.Attributes["container"][:12], err)
 					return
 				}
 				if err := dd.updateContainerInfo(container); err != nil {
-					log.Printf("[docker] Error adding A record for container %s: %s", msg.ID, err)
+					log.Printf("[docker] Error adding A record for container %s: %s", container.ID[:12], err)
 				}
 			case "network:disconnect":
 				log.Printf("[docker] Container %s being disconnected from network %s", msg.Actor.Attributes["container"][:12], msg.Actor.Attributes["name"])

--- a/dockerdiscovery.go
+++ b/dockerdiscovery.go
@@ -247,16 +247,16 @@ func (dd DockerDiscovery) start() error {
 
 				container, err := dd.dockerClient.InspectContainer(msg.Actor.ID)
 				if err != nil {
-					log.Printf("[docker] Event error %s #%s: %s", event, msg.Actor.ID, err)
+					log.Printf("[docker] Event error %s #%s: %s", event, msg.Actor.ID[:12], err)
 					return
 				}
 				if err := dd.updateContainerInfo(container); err != nil {
 					log.Printf("[docker] Error adding A record for container %s: %s", container.ID[:12], err)
 				}
 			case "container:die":
-				log.Println("[docker] Container being stopped. Attempt to remove its A record from the DNS", msg.Actor.ID)
+				log.Println("[docker] Container being stopped. Attempt to remove its A record from the DNS", msg.Actor.ID[:12])
 				if err := dd.removeContainerInfo(msg.Actor.ID); err != nil {
-					log.Printf("[docker] Error deleting A record for container: %s: %s", msg.Actor.ID, err)
+					log.Printf("[docker] Error deleting A record for container: %s: %s", msg.Actor.ID[:12], err)
 				}
 			case "network:connect":
 				// take a look https://gist.github.com/josefkarasek/be9bac36921f7bc9a61df23451594fbf for example of same event's types attributes


### PR DESCRIPTION
Just noted: Sometimes "network:disconnect" throws "unable to find network settings for the network" error.
```container.HostConfig.NetworkMode``` contains value while ```Networks``` map key is not exist in ```container.NetworkSettings``` .
Example from my case:
```container.NetworkSettings``` equals ```{ "SandboxKey": "/var/run/docker/netns/8a2df831a89f" }```
```container.HostConfig.NetworkMode``` equals ```"my_network"```
Merge with squash