### PR TITLE
fix compilation with last coredns version

### DIFF
--- a/dockerdiscovery.go
+++ b/dockerdiscovery.go
@@ -91,7 +91,7 @@ func (dd DockerDiscovery) ServeDNS(ctx context.Context, w dns.ResponseWriter, r 
 	m.Answer = answers
 
 	state.SizeAndDo(m)
-	m, _ = state.Scrub(m)
+	m = state.Scrub(m)
 	w.WriteMsg(m)
 	return dns.RcodeSuccess, nil
 }


### PR DESCRIPTION
Now It does't compilate. broke with error 
`dockerdiscovery.go:94:7: assignment mismatch: 2 variables but 1 values`
Some method was changed in there https://github.com/coredns/coredns/commit/ba1efee4f1c2258e43b1bd8035ac6d1208675b95#diff-960473a6998c1867436ca51f953284feR241
Fix it.