### PR TITLE
Add directive to define domain for container name

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Start a docker container:
     $ docker run -d --name my-alpine --hostname alpine alpine sleep 1000
     78c2a06ef2a9b63df857b7985468f7310bba0d9ea4d0d2629343aff4fd171861
 
-Use CoreDNS as your resolver to resolve the `my-alpine.docker.loc` or `alpha.docker.loc`:
+Use CoreDNS as your resolver to resolve the `my-alpine.docker.loc` or `alpine.docker.loc`:
 
     $ dig @localhost -p 15353 my-alpine.docker.loc
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Example
     .:15353 {
         docker unix:///var/run/docker.sock {
             domain docker.loc
-            hostname_domain docker.loc
+            hostname_domain docker-host.loc
         }
         log
     }
@@ -70,7 +70,7 @@ Start a docker container:
     $ docker run -d --name my-alpine --hostname alpine alpine sleep 1000
     78c2a06ef2a9b63df857b7985468f7310bba0d9ea4d0d2629343aff4fd171861
 
-Use CoreDNS as your resolver to resolve the `my-alpine.docker.loc` or `alpine.docker.loc`:
+Use CoreDNS as your resolver to resolve the `my-alpine.docker.loc` or `alpine.docker-host.loc`:
 
     $ dig @localhost -p 15353 my-alpine.docker.loc
 

--- a/dockerdiscovery.go
+++ b/dockerdiscovery.go
@@ -91,7 +91,7 @@ func (dd DockerDiscovery) ServeDNS(ctx context.Context, w dns.ResponseWriter, r 
 	m.Answer = answers
 
 	state.SizeAndDo(m)
-	m, _ = state.Scrub(m)
+	m = state.Scrub(m)
 	w.WriteMsg(m)
 	return dns.RcodeSuccess, nil
 }

--- a/resolvers.go
+++ b/resolvers.go
@@ -7,6 +7,16 @@ import (
 
 // resolvers implements ContainerDomainResolver
 
+type SubDomainContainerNameResolver struct {
+	domain string
+}
+func (resolver SubDomainContainerNameResolver) resolve(container *dockerapi.Container) ([]string, error) {
+	var domains []string
+	domains = append(domains, fmt.Sprintf("%s.%s", container.Name, resolver.domain))
+	return domains, nil
+}
+
+
 type SubDomainHostResolver struct {
 	domain string
 }

--- a/setup.go
+++ b/setup.go
@@ -10,7 +10,7 @@ import (
 )
 
 const defaultDockerEndpoint = "unix:///var/run/docker.sock"
-const defaultDockerDomain = "docker.local."
+const defaultDockerDomain = "docker.local"
 
 func init() {
 	caddy.RegisterPlugin("docker", caddy.Plugin{
@@ -39,6 +39,15 @@ func createPlugin(c *caddy.Controller) (DockerDiscovery, error) {
 			var value = c.Val()
 			switch value {
 			case "domain":
+				var resolver = &SubDomainContainerNameResolver{
+					domain: defaultDockerDomain,
+				}
+				dd.resolvers = append(dd.resolvers, resolver)
+				if !c.NextArg() {
+					return dd, c.ArgErr()
+				}
+				resolver.domain = c.Val()
+			case "hostname_domain":
 				var resolver = &SubDomainHostResolver{
 					domain: defaultDockerDomain,
 				}

--- a/setup_test.go
+++ b/setup_test.go
@@ -1,6 +1,7 @@
 package dockerdiscovery
 
 import (
+	"fmt"
 	"testing"
 	"net"
 
@@ -30,14 +31,14 @@ func TestSetupDockerDiscovery(t *testing.T) {
 		},
 		setupDockerDiscoveryTestCase{
 			`docker {
-	domain example.org.
+	hostname_domain example.org.
 }`,
 			defaultDockerEndpoint,
 			"example.org.",
 		},
 		setupDockerDiscoveryTestCase{
 			`docker unix:///home/user/docker.sock {
-	domain home.example.org.
+	hostname_domain home.example.org.
 }`,
 			"unix:///home/user/docker.sock",
 			"home.example.org.",
@@ -52,7 +53,8 @@ func TestSetupDockerDiscovery(t *testing.T) {
 	}
 
 	c := caddy.NewTestController("dns", `docker unix:///home/user/docker.sock {
-	domain home.example.org
+	hostname_domain home.example.org
+	domain docker.loc
 	network_aliases my_project_network_name
 }`)
 	dd, err := createPlugin(c)
@@ -100,4 +102,9 @@ func TestSetupDockerDiscovery(t *testing.T) {
 
 	containerInfo, e = dd.containerInfoByDomain("label-host.loc.")
 	assert.NotNil(t, containerInfo)
+
+
+	containerInfo, e = dd.containerInfoByDomain(fmt.Sprintf("%s.docker.loc.", container.Name))
+	assert.NotNil(t, containerInfo)
+	assert.Equal(t, container.Name, containerInfo.container.Name)
 }


### PR DESCRIPTION
Container name is required indicator. Will be convenient to have access by container name as subdomain.
I rename `domain` directive to `hostname_domain`. `domain` work as domain for container's names