### PR TITLE
Compose and multiple networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,16 @@ Syntax
         hostname_domain HOSTNAME_DOMAIN_NAME
         network_aliases DOCKER_NETWORK
         label LABEL
+        compose_domain COMPOSE_DOMAIN_NAME
     }
 
 * `DOCKER_ENDPOINT`: the path to the docker socket. If unspecified, defaults to `unix:///var/run/docker.sock`. It can also be TCP socket, such as `tcp://127.0.0.1:999`.
 * `DOMAIN_NAME`: the name of the domain for [container name](https://docs.docker.com/engine/reference/run/#name---name), e.g. when `DOMAIN_NAME` is `docker.loc`, your container with `my-nginx` (as subdomain) [name](https://docs.docker.com/engine/reference/run/#name---name) will be assigned the domain name: `my-nginx.docker.loc`
 * `HOSTNAME_DOMAIN_NAME`: the name of the domain for [hostname](https://docs.docker.com/config/containers/container-networking/#ip-address-and-hostname). Work same as `DOMAIN_NAME` for hostname.
+* `COMPOSE_DOMAIN_NAME`: the name of the domain when it is determined the
+    container is managed by docker-compose.  e.g. for a compose project of
+    "internal" and service of "nginx", if `COMPOSE_DOMAIN_NAME` is
+    `compose.loc` the fqdn will be `nginx.internal.compoes.loc`
 * `DOCKER_NETWORK`: the name of the docker network. Resolve directly by [network aliases](https://docs.docker.com/v17.09/engine/userguide/networking/configure-dns) (like internal docker dns resolve host by aliases whole network)
 * `LABEL`: container label of resolving host (by default enable and equals ```coredns.dockerdiscovery.host```)
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Syntax
 * `COMPOSE_DOMAIN_NAME`: the name of the domain when it is determined the
     container is managed by docker-compose.  e.g. for a compose project of
     "internal" and service of "nginx", if `COMPOSE_DOMAIN_NAME` is
-    `compose.loc` the fqdn will be `nginx.internal.compoes.loc`
+    `compose.loc` the fqdn will be `nginx.internal.compose.loc`
 * `DOCKER_NETWORK`: the name of the docker network. Resolve directly by [network aliases](https://docs.docker.com/v17.09/engine/userguide/networking/configure-dns) (like internal docker dns resolve host by aliases whole network)
 * `LABEL`: container label of resolving host (by default enable and equals ```coredns.dockerdiscovery.host```)
 

--- a/dockerdiscovery.go
+++ b/dockerdiscovery.go
@@ -1,16 +1,16 @@
 package dockerdiscovery
 
 import (
-	"github.com/coredns/coredns/plugin"
-	dockerapi "github.com/fsouza/go-dockerclient"
-	"fmt"
-	"net"
 	"context"
-	"github.com/miekg/dns"
-	"github.com/coredns/coredns/request"
-	"log"
-	"strings"
 	"errors"
+	"fmt"
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/request"
+	dockerapi "github.com/fsouza/go-dockerclient"
+	"github.com/miekg/dns"
+	"log"
+	"net"
+	"strings"
 )
 
 type ContainerInfo struct {
@@ -28,18 +28,19 @@ type ContainerDomainResolver interface {
 
 // DockerDiscovery is a plugin that conforms to the coredns plugin interface
 type DockerDiscovery struct {
-	Next           plugin.Handler
-	dockerEndpoint string
-	resolvers 	   []ContainerDomainResolver
-	dockerClient   *dockerapi.Client
-	containerInfoMap   ContainerInfoMap
-	domainIPMap 	map[string]*net.IP
+	Next             plugin.Handler
+	dockerEndpoint   string
+	resolvers        []ContainerDomainResolver
+	dockerClient     *dockerapi.Client
+	containerInfoMap ContainerInfoMap
+	domainIPMap      map[string]*net.IP
 }
+
 // NewDockerDiscovery constructs a new DockerDiscovery object
 func NewDockerDiscovery(dockerEndpoint string) DockerDiscovery {
 	return DockerDiscovery{
-		dockerEndpoint: dockerEndpoint,
-		containerInfoMap:   make(ContainerInfoMap),
+		dockerEndpoint:   dockerEndpoint,
+		containerInfoMap: make(ContainerInfoMap),
 	}
 }
 
@@ -133,7 +134,7 @@ func (dd DockerDiscovery) getContainerAddress(container *dockerapi.Container) (n
 				return nil, fmt.Errorf("unable to find network settings for the network %s", networkMode)
 			}
 
-			return net.ParseIP(network.IPAddress), nil  // ParseIP return nil when IPAddress equals ""
+			return net.ParseIP(network.IPAddress), nil // ParseIP return nil when IPAddress equals ""
 		}
 	}
 }
@@ -154,8 +155,8 @@ func (dd DockerDiscovery) updateContainerInfo(container *dockerapi.Container) er
 	if len(domains) > 0 {
 		dd.containerInfoMap[container.ID] = &ContainerInfo{
 			container: container,
-			address: containerAddress,
-			domains: domains,
+			address:   containerAddress,
+			domains:   domains,
 		}
 
 		if !isExist {

--- a/dockerdiscovery.go
+++ b/dockerdiscovery.go
@@ -113,7 +113,7 @@ func (dd DockerDiscovery) getContainerAddress(container *dockerapi.Container) (n
 	var networkMode string
 
 	for {
-		if container.NetworkSettings.IPAddress != "" {
+		if container.NetworkSettings.IPAddress != "" && !hasNetName {
 			return net.ParseIP(container.NetworkSettings.IPAddress), nil
 		}
 

--- a/resolvers.go
+++ b/resolvers.go
@@ -1,8 +1,8 @@
 package dockerdiscovery
 
 import (
-	dockerapi "github.com/fsouza/go-dockerclient"
 	"fmt"
+	dockerapi "github.com/fsouza/go-dockerclient"
 	"strings"
 )
 
@@ -15,44 +15,44 @@ func normalizeContainerName(container *dockerapi.Container) string {
 type SubDomainContainerNameResolver struct {
 	domain string
 }
+
 func (resolver SubDomainContainerNameResolver) resolve(container *dockerapi.Container) ([]string, error) {
 	var domains []string
 	domains = append(domains, fmt.Sprintf("%s.%s", normalizeContainerName(container), resolver.domain))
 	return domains, nil
 }
 
-
 type SubDomainHostResolver struct {
 	domain string
 }
+
 func (resolver SubDomainHostResolver) resolve(container *dockerapi.Container) ([]string, error) {
 	var domains []string
 	domains = append(domains, fmt.Sprintf("%s.%s", container.Config.Hostname, resolver.domain))
 	return domains, nil
 }
 
-
 type LabelResolver struct {
 	hostLabel string
 }
+
 func (resolver LabelResolver) resolve(container *dockerapi.Container) ([]string, error) {
 	var domains []string
 
-	for label, value :=  range container.Config.Labels {
+	for label, value := range container.Config.Labels {
 		if label == resolver.hostLabel {
 			domains = append(domains, value)
-			break;
+			break
 		}
 	}
 
 	return domains, nil
 }
 
-
-
 type NetworkAliasesResolver struct {
 	network string
 }
+
 func (resolver NetworkAliasesResolver) resolve(container *dockerapi.Container) ([]string, error) {
 	var domains []string
 
@@ -69,4 +69,3 @@ func (resolver NetworkAliasesResolver) resolve(container *dockerapi.Container) (
 
 	return domains, nil
 }
-

--- a/setup.go
+++ b/setup.go
@@ -56,6 +56,15 @@ func createPlugin(c *caddy.Controller) (DockerDiscovery, error) {
 					return dd, c.ArgErr()
 				}
 				resolver.domain = c.Val()
+			case "compose_domain":
+				var resolver = &ComposeResolver{
+					domain: defaultDockerDomain,
+				}
+				dd.resolvers = append(dd.resolvers, resolver)
+				if !c.NextArg() {
+					return dd, c.ArgErr()
+				}
+				resolver.domain = c.Val()
 			case "network_aliases":
 				var resolver = &NetworkAliasesResolver{
 					network: "",

--- a/setup_test.go
+++ b/setup_test.go
@@ -16,7 +16,7 @@ type setupDockerDiscoveryTestCase struct {
 	expectedDockerDomain   string
 }
 
-func TestSetupDockerDiscovery(t *testing.T) {
+func TestConfigDockerDiscovery(t *testing.T) {
 	testCases := []setupDockerDiscoveryTestCase{
 		setupDockerDiscoveryTestCase{
 			"docker",
@@ -50,58 +50,93 @@ func TestSetupDockerDiscovery(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, dd.dockerEndpoint, tc.expectedDockerEndpoint)
 	}
+}
 
-	c := caddy.NewTestController("dns", `docker unix:///home/user/docker.sock {
+func TestSetupDockerDiscovery(t *testing.T) {
+	networkName := "my_project_network_name"
+	c := caddy.NewTestController("dns", fmt.Sprintf(`docker unix:///home/user/docker.sock {
+	compose_domain compose.loc
 	hostname_domain home.example.org
 	domain docker.loc
-	network_aliases my_project_network_name
-}`)
+	network_aliases %s
+}`, networkName))
 	dd, err := createPlugin(c)
 	assert.Nil(t, err)
 
-	networks := make(map[string]dockerapi.ContainerNetwork)
-	var aliases = []string{"myproject.loc"}
-
-	networks["my_project_network_name"] = dockerapi.ContainerNetwork{
-		Aliases: aliases,
-	}
 	var address = net.ParseIP("192.11.0.1")
-	var container = &dockerapi.Container{
+	var containers = []*dockerapi.Container{
+		genContainerDefn(address.String(), networkName, ""),
+		genContainerDefn("", networkName, address.String()),
+		genContainerDefn(address.String(), networkName, address.String()),
+	}
+
+	for i := range containers {
+		container := containers[i]
+		e := dd.updateContainerInfo(container)
+		assert.Nil(t, e)
+
+		_ = ipOk(t, dd, "myproject.loc.", address)
+		ipNotOk(t, dd, "wrong.loc.")
+		_ = ipOk(t, dd, "nginx.home.example.org.", address)
+		ipNotOk(t, dd, "wrong.home.example.org.")
+		_ = ipOk(t, dd, "label-host.loc.", address)
+		_ = ipOk(t, dd, "cservice.cproject.compose.loc.", address)
+
+		containerInfo := ipOk(t, dd, fmt.Sprintf("%s.docker.loc.", container.Name), address)
+		assert.Equal(t, container.Name, containerInfo.container.Name)
+	}
+}
+
+// simple check
+func ipOk(t *testing.T, dd DockerDiscovery, domain string, address net.IP) *ContainerInfo {
+
+	containerInfo, e := dd.containerInfoByDomain(domain)
+	assert.Nil(t, e)
+	assert.NotNil(t, containerInfo)
+
+	// check as strings here, for us poor mortals
+	assert.Equal(t, address.String(), containerInfo.address.String())
+
+	return containerInfo
+}
+
+// simple check
+func ipNotOk(t *testing.T, dd DockerDiscovery, domain string) {
+
+	containerInfo, e := dd.containerInfoByDomain(domain)
+	assert.Nil(t, e)
+	assert.Nil(t, containerInfo)
+
+	return
+}
+
+// string, not net.IP, as 1) we're test, 2) the underling struct is a string,
+// and 3) we may want something odd here
+func genContainerDefn(nsAddress string, netMode string, netAddress string) *dockerapi.Container {
+	container := &dockerapi.Container{
 		ID:   "fa155d6fd141e29256c286070d2d44b3f45f1e46822578f1e7d66c1e7981e6c7",
 		Name: "evil_ptolemy",
 		Config: &dockerapi.Config{
 			Hostname: "nginx",
-			Labels:   map[string]string{"coredns.dockerdiscovery.host": "label-host.loc"},
+			Labels: map[string]string{
+				"coredns.dockerdiscovery.host": "label-host.loc",
+				"com.docker.compose.project":   "cproject",
+				"com.docker.compose.service":   "cservice",
+			},
+		},
+		HostConfig: &dockerapi.HostConfig{
+			NetworkMode: netMode,
 		},
 		NetworkSettings: &dockerapi.NetworkSettings{
-			Networks:  networks,
-			IPAddress: address.String(),
+			IPAddress: nsAddress,
+			Networks: map[string]dockerapi.ContainerNetwork{
+				netMode: dockerapi.ContainerNetwork{
+					Aliases:   []string{"myproject.loc"},
+					IPAddress: netAddress,
+				},
+			},
 		},
 	}
 
-	e := dd.updateContainerInfo(container)
-	assert.Nil(t, e)
-
-	containerInfo, e := dd.containerInfoByDomain("myproject.loc.")
-	assert.Nil(t, e)
-	assert.NotNil(t, containerInfo)
-	assert.NotNil(t, containerInfo.address)
-
-	assert.Equal(t, containerInfo.address, address)
-
-	containerInfo, e = dd.containerInfoByDomain("wrong.loc.")
-	assert.Nil(t, containerInfo)
-
-	containerInfo, e = dd.containerInfoByDomain("nginx.home.example.org.")
-	assert.NotNil(t, containerInfo)
-
-	containerInfo, e = dd.containerInfoByDomain("wrong.home.example.org.")
-	assert.Nil(t, containerInfo)
-
-	containerInfo, e = dd.containerInfoByDomain("label-host.loc.")
-	assert.NotNil(t, containerInfo)
-
-	containerInfo, e = dd.containerInfoByDomain(fmt.Sprintf("%s.docker.loc.", container.Name))
-	assert.NotNil(t, containerInfo)
-	assert.Equal(t, container.Name, containerInfo.container.Name)
+	return container
 }


### PR DESCRIPTION
This PR does a number of things:

* Adds a new resolver, `ComposeResolver`, that uses labels applied by `docker-compose` to construct sensible domains
* Allows the IP to be taken from a specific network, when a given label (`coredns.dockerdiscovery.network`) is applied to the container
* Refactors `setup_test.go` a bit to (hopefully) make things clearer when adding new tests

Changes from `go fmt` etc are made in a distinct commit at the beginning, so later changes are a bit clearer, without its tidying confusing the diff.

As an aside, normally I'd try to submit this as multiple PR's.  However, both the multiple-networks and `ComposeResolver` changes would end up conflicting given the test changes, so I'm submitting them together.  I'm happy to go back and break them out, however.