### PR TITLE
Switched to pointer receiver

### DIFF
--- a/dockerdiscovery.go
+++ b/dockerdiscovery.go
@@ -41,14 +41,14 @@ type DockerDiscovery struct {
 }
 
 // NewDockerDiscovery constructs a new DockerDiscovery object
-func NewDockerDiscovery(dockerEndpoint string) DockerDiscovery {
-	return DockerDiscovery{
+func NewDockerDiscovery(dockerEndpoint string) *DockerDiscovery {
+	return &DockerDiscovery{
 		dockerEndpoint:   dockerEndpoint,
 		containerInfoMap: make(ContainerInfoMap),
 	}
 }
 
-func (dd DockerDiscovery) resolveDomainsByContainer(container *dockerapi.Container) ([]string, error) {
+func (dd *DockerDiscovery) resolveDomainsByContainer(container *dockerapi.Container) ([]string, error) {
 	var domains []string
 	for _, resolver := range dd.resolvers {
 		var d, err = resolver.resolve(container)
@@ -61,7 +61,7 @@ func (dd DockerDiscovery) resolveDomainsByContainer(container *dockerapi.Contain
 	return domains, nil
 }
 
-func (dd DockerDiscovery) containerInfoByDomain(requestName string) (*ContainerInfo, error) {
+func (dd *DockerDiscovery) containerInfoByDomain(requestName string) (*ContainerInfo, error) {
 	dd.mutex.RLock()
 	defer dd.mutex.RUnlock()
 
@@ -77,7 +77,7 @@ func (dd DockerDiscovery) containerInfoByDomain(requestName string) (*ContainerI
 }
 
 // ServeDNS implements plugin.Handler
-func (dd DockerDiscovery) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+func (dd *DockerDiscovery) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	state := request.Request{W: w, Req: r}
 	var answers []dns.RR
 	switch state.QType() {
@@ -108,11 +108,11 @@ func (dd DockerDiscovery) ServeDNS(ctx context.Context, w dns.ResponseWriter, r 
 }
 
 // Name implements plugin.Handler
-func (dd DockerDiscovery) Name() string {
+func (dd *DockerDiscovery) Name() string {
 	return "docker"
 }
 
-func (dd DockerDiscovery) getContainerAddress(container *dockerapi.Container) (net.IP, error) {
+func (dd *DockerDiscovery) getContainerAddress(container *dockerapi.Container) (net.IP, error) {
 
 	// save this away
 	netName, hasNetName := container.Config.Labels["coredns.dockerdiscovery.network"]
@@ -158,7 +158,7 @@ func (dd DockerDiscovery) getContainerAddress(container *dockerapi.Container) (n
 	return net.ParseIP(network.IPAddress), nil // ParseIP return nil when IPAddress equals ""
 }
 
-func (dd DockerDiscovery) updateContainerInfo(container *dockerapi.Container) error {
+func (dd *DockerDiscovery) updateContainerInfo(container *dockerapi.Container) error {
 	dd.mutex.Lock()
 	defer dd.mutex.Unlock()
 
@@ -190,7 +190,7 @@ func (dd DockerDiscovery) updateContainerInfo(container *dockerapi.Container) er
 	return nil
 }
 
-func (dd DockerDiscovery) removeContainerInfo(containerID string) error {
+func (dd *DockerDiscovery) removeContainerInfo(containerID string) error {
 	dd.mutex.Lock()
 	defer dd.mutex.Unlock()
 
@@ -205,7 +205,7 @@ func (dd DockerDiscovery) removeContainerInfo(containerID string) error {
 	return nil
 }
 
-func (dd DockerDiscovery) start() error {
+func (dd *DockerDiscovery) start() error {
 	log.Println("[docker] start")
 	events := make(chan *dockerapi.APIEvents)
 

--- a/setup.go
+++ b/setup.go
@@ -20,7 +20,7 @@ func init() {
 }
 
 // TODO(kevinjqiu): add docker endpoint verification
-func createPlugin(c *caddy.Controller) (DockerDiscovery, error) {
+func createPlugin(c *caddy.Controller) (*DockerDiscovery, error) {
 	dd := NewDockerDiscovery(defaultDockerEndpoint)
 	labelResolver := &LabelResolver{hostLabel: "coredns.dockerdiscovery.host"}
 	dd.resolvers = append(dd.resolvers, labelResolver)

--- a/setup_test.go
+++ b/setup_test.go
@@ -127,7 +127,7 @@ func TestMultipleNetworksDockerDiscovery(t *testing.T) {
 }
 
 // simple check
-func ipOk(t *testing.T, dd DockerDiscovery, domain string, address net.IP) *ContainerInfo {
+func ipOk(t *testing.T, dd *DockerDiscovery, domain string, address net.IP) *ContainerInfo {
 
 	containerInfo, e := dd.containerInfoByDomain(domain)
 	assert.Nil(t, e)
@@ -140,7 +140,7 @@ func ipOk(t *testing.T, dd DockerDiscovery, domain string, address net.IP) *Cont
 }
 
 // simple check
-func ipNotOk(t *testing.T, dd DockerDiscovery, domain string) {
+func ipNotOk(t *testing.T, dd *DockerDiscovery, domain string) {
 
 	containerInfo, e := dd.containerInfoByDomain(domain)
 	assert.Nil(t, e)


### PR DESCRIPTION
A bit embarrassing as I only noticed this now. But due to the DockerDiscovery struct using value receivers everywhere my previous pull request #22 was effectively useless, as it copied the mutex by value rather than by pointer. Which is something a linter would have pointed out almost instantly. I think time actually ran (with data race detector enabled) my changes in my homelab to confirm that it works accordingly.